### PR TITLE
fix: use DOCKER_BUILDKIT=1 with --provenance=false to prevent image index generation

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -80,6 +80,6 @@ jobs:
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.
-          docker buildx build --build-arg TOKEN=${{ secrets.DEVOPS_TOKEN }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          DOCKER_BUILDKIT=1 docker build --provenance=false --build-arg TOKEN=${{ secrets.DEVOPS_TOKEN }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Replace `docker buildx build` with `DOCKER_BUILDKIT=1 docker build --provenance=false` in GitHub Actions workflow
- Prevents GitHub Actions from generating an image index instead of an actual Docker image
- The `--provenance=false` flag disables provenance attestation which causes image index creation

## Test plan
- [ ] Verify the GitHub Actions workflow runs successfully
- [ ] Confirm the ECR image is a standard image (not an image index)